### PR TITLE
Add testing to the example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /elm.js
 /elm-stuff/
+/target/
+/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-elm-stuff
+/elm.js
+/elm-stuff/

--- a/elm-io.sh
+++ b/elm-io.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <generated-js-file> <output-file>"
+    exit 1
+fi
+
+read -d '' before <<- EOF
+var jsdom = require("jsdom");
+var callback = function(errors, window) {
+  var document = window.document;
+// Elm goes here:
+EOF
+
+read -d '' handler <<- EOF
+// Elm goes there ^
+(function(){
+    var stdin = process.stdin;
+    var fs    = require('fs');
+    var worker = Elm.worker(Elm.Main
+                            , {responses: null }
+                           );
+    var just = function(v) {
+        return { 'Just': v};
+    }
+    var handle = function(request) {
+        // Debugging:
+        // console.log("Bleh: %j", request);
+        switch(request.ctor) {
+        case 'Put':
+            process.stdout.write(request.val);
+            break;
+        case 'Get':
+            stdin.resume();
+            break;
+        case 'Exit':
+            process.exit(request.val);
+            break;
+        case 'WriteFile':
+            fs.writeFileSync(request.file, request.content);
+            break;
+        }
+    }
+    var handler = function(reqs) {
+        for (var i = 0; i < reqs.length; i++) {
+            handle(reqs[i]);
+        }
+        if (reqs.length > 0 && reqs[reqs.length - 1].ctor !== 'Get') {
+            worker.ports.responses.send(just(""));
+        }
+    }
+    worker.ports.requests.subscribe(handler);
+    
+    // Read
+    stdin.on('data', function(chunk) {
+        //console.log('Got' + chunk);
+        stdin.pause();
+        worker.ports.responses.send(just(chunk.toString()));
+    })
+
+    // Start msg
+    worker.ports.responses.send(null);
+})();
+} // Close the callback
+// Run!
+jsdom.env('<p>bleh</p>', [], callback);
+EOF
+
+touch $2
+echo "$before" > $2
+cat $1 >> $2
+echo "$handler" >> $2

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,10 @@
         "StartApp"
     ],
     "dependencies": {
+        "deadfoxygrandpa/Elm-Test": "1.0.4 <= v < 2.0.0",
         "elm-lang/core": "2.0.1 <= v < 3.0.0",
-        "evancz/elm-html": "3.0.0 <= v < 4.0.0"
+        "evancz/elm-html": "3.0.0 <= v < 4.0.0",
+        "maxsnew/IO": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -v
+
+if [ "$1" == "--clean" ]; then
+  rm -Rf elm-stuff/build-artifacts
+fi
+
+if [ ! -d node_modules/jsdom ]; then
+  npm install jsdom@3
+fi
+
+mkdir -p target
+elm-make src/Test/TestMain.elm --output target/test.js
+./elm-io.sh target/test.js target/test.io.js
+node target/test.io.js

--- a/src/StartAppTest.elm
+++ b/src/StartAppTest.elm
@@ -1,0 +1,8 @@
+module StartAppTest where
+
+import ElmTest.Test as Test exposing (test, Test)
+import ElmTest.Assertion exposing (assert, assertEqual)
+
+suite = Test.suite "StartApp"
+  [ test "Addition" <| assertEqual (3 + 7) 10
+  ]

--- a/src/Test/TestMain.elm
+++ b/src/Test/TestMain.elm
@@ -1,0 +1,21 @@
+module Main where
+
+import IO.IO exposing (..)
+import IO.Runner exposing (Request, Response, run)
+
+import ElmTest.Test as Test
+import ElmTest.Runner.Console as Console
+
+import StartAppTest
+
+allTests = Test.suite ""
+  [ StartAppTest.suite
+  ]
+
+testRunner : IO ()
+testRunner = Console.runDisplay allTests
+
+port requests : Signal Request
+port requests = run responses testRunner
+
+port responses : Signal Response


### PR DESCRIPTION
This is a first stab at adding testing to the starter project using `deadfoxygrandpa/Elm-Test`.

Tests can be run with `./run-tests.sh`, but requires that `npm` is available and is able to install `jsdom@3`.

Possible improvements:
- have a web-based runner for people who can't use IO
