### PR TITLE
Make example instructions for running clear for non-online editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ update action model =
 ```
 
 <span style="color:grey;">
-Paste the code into [Elm's online editor][edit] to see it in action.
+Paste the code into [Elm's online editor][edit] or save it into `index.elm` and run `elm-reactor` to see it in action.
 </span>
 
 Notice that the `update` and `view` functions are totally separate. This is


### PR DESCRIPTION
Just adds instructions to save the example into a file and run elm-reactor. Not much of a change but someone I was teaching asked me what to do once they ran elm-package locally, so this may help clear things up.
