### PR TITLE
Quick fix: Readme not ready for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Try it [online][edit] or install [Elm Platform](https://www.npmjs.com/package/el
 and run these commands to get all the relevant packages locally:
 
 ```
-elm-package install evancz/start-app
+elm-package install evancz/start-app 1.0.0
 elm-package install evancz/elm-html
 ```
 


### PR DESCRIPTION
This should avoid problems like #18

Surely, Readme should adopt the changes brought in by v2.0.0 / Effects.
This should be in sync with updating elm-lang.org/try
