### PR TITLE
Point to elm-lang.org install page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ setting everything up so you can focus entirely on writing your app.
 [arch]: https://github.com/evancz/elm-architecture-tutorial/
 [elm-html]: http://elm-lang.org/blog/Blazing-Fast-Html.elm
 
-Try it [online][edit] or install [Elm Platform](https://www.npmjs.com/package/elm)
+Try it [online][edit] or install [Elm Platform](http://elm-lang.org/install)
 and run these commands to get all the relevant packages locally:
 
 ```


### PR DESCRIPTION
I found this article before finding elm-lang.org. It directed me to install elm via NPM, which has errors on a mac, and doesn't seem to be recommended. This changes the link to the install page of elm-lang.org instead.
