### PR TITLE
Adapt to be able to deal with batched tick sending

### DIFF
--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -79,21 +79,30 @@ tasks into a `port` that will run them all.
 start : Config model action -> App model
 start config =
     let
-        -- messages : Signal.Mailbox (Maybe action)
+        singleton action = [ action ]
+
+        -- messages : Signal.Mailbox (List action)
         messages =
-            Signal.mailbox Nothing
+            Signal.mailbox []
 
         -- address : Signal.Address action
         address =
-            Signal.forwardTo messages.address Just
+            Signal.forwardTo messages.address singleton
 
-        -- update : Maybe action -> (model, Effects action) -> (model, Effects action)
-        update (Just action) (model, _) =
-            config.update action model
+        -- updateStep : action -> (model, Effects action) -> (model, Effects action)
+        updateStep action (oldModel, accumulatedEffects) =
+            let
+                (newModel, additionalEffects) = config.update action oldModel
+            in
+                (newModel, Effects.batch [accumulatedEffects, additionalEffects])
 
-        -- inputs : Signal (Maybe action)
+        -- update : List action -> (model, Effects action) -> (model, Effects action)
+        update actions (model, _) =
+            List.foldl updateStep (model, Effects.none) actions
+
+        -- inputs : Signal (List action)
         inputs =
-            Signal.mergeMany (messages.signal :: List.map (Signal.map Just) config.inputs)
+            Signal.mergeMany (messages.signal :: List.map (Signal.map singleton) config.inputs)
 
         -- effectsAndModel : Signal (model, Effects action)
         effectsAndModel =
@@ -104,5 +113,5 @@ start config =
     in
         { html = Signal.map (config.view address) model
         , model = model
-        , tasks = Signal.map (Effects.toTask address << snd) effectsAndModel
+        , tasks = Signal.map (Effects.toTask messages.address << snd) effectsAndModel
         }


### PR DESCRIPTION
This is a companion PR to https://github.com/evancz/elm-effects/pull/24.

Note that nothing changes in terms of API for users of `start-app`. But since `elm-effects` will need to have a major version bump, the relevant version constraint in `elm-package.json` here will have to be changed. The package `start-app` itself only needs a patch release.
