### PR TITLE
Expose the `Signal.Address` which `StartApp` uses internally.

### DIFF
--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -17,6 +17,7 @@ works!**
 import Html exposing (Html)
 import Task
 import Effects exposing (Effects, Never)
+import Signal exposing (Address)
 
 
 {-| The configuration of an app follows the basic model / update / view pattern
@@ -49,13 +50,19 @@ type alias Config model action =
     will not need this one, but it is there just in case. You will know if you
     need this.
 
+  * `address` &mdash; an `Address action` that you can send actions to.
+    Normally you will not need this. For instance, if you have a `Signal action`
+    available before calling `start`, you can supply it to `start` via the
+    `inputs` field.
+
   * `tasks` &mdash; a signal of tasks that need to get run. Your app is going
     to be producing tasks in response to all sorts of events, so this needs to
     be hooked up to a `port` to ensure they get run.
 -}
-type alias App model =
+type alias App model action =
     { html : Signal Html
     , model : Signal model
+    , address : Address action
     , tasks : Signal (Task.Task Never ())
     }
 
@@ -76,7 +83,7 @@ type alias App model =
 So once we start the `App` we feed the HTML into `main` and feed the resulting
 tasks into a `port` that will run them all.
 -}
-start : Config model action -> App model
+start : Config model action -> App model action
 start config =
     let
         singleton action = [ action ]
@@ -113,5 +120,6 @@ start config =
     in
         { html = Signal.map (config.view address) model
         , model = model
+        , address = address
         , tasks = Signal.map (Effects.toTask messages.address << snd) effectsAndModel
         }


### PR DESCRIPTION
This PR would address the scenario identified in #29.

Note that client code would not normally need to access the `Signal.Address`, since it would normally be sufficient for client code to supply a `Signal action` as one of the `Config.inputs` when calling `start`. So, this PR would address an unusual or rare situation.

So, part of the issue is how start-app intends to deal with unusual or rare situations, as discussed in #29. 
- One option would be to say: if you have an unusual or rare situation, simply make a local copy of start-app and modify it as needed. In that case, one would expect that this PR might be rejected.
- Another option would be to expose more of the internals of start-app, so that clients can deal with unusual or rare situations without having to modify start-app itself.

I don't have a strong preference as between those two options.
