### PR TITLE
use initial value of inputs without discarding them

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
         "StartApp.Simple"
     ],
     "dependencies": {
+        "Apanatshka/elm-signal-extra": "5.6.0 <= v < 6.0.0",
         "elm-lang/core": "2.0.1 <= v < 4.0.0",
         "evancz/elm-effects": "2.0.0 <= v < 3.0.0",
         "evancz/elm-html": "3.0.0 <= v < 5.0.0"

--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -106,22 +106,16 @@ start config =
         update actions (model, _) =
             List.foldl updateStep (model, Effects.none) actions
 
-        -- updateStart : List Action -> (model, Effects action)
+        -- updateStart : List action -> (model, Effects action)
         updateStart actions =
             List.foldl updateStep config.init actions
 
-        mergedInputs =
+        -- inputs : Signal (List action)
+        inputs =
           List.foldl
             (Signal.Extra.fairMerge List.append)
             messages.signal
-            (List.map (Signal.map singleton) config.inputs)
-
-        mergedInits =
-          List.map (Signal.map singleton) config.inits
-
-        -- inputs : Signal (List action)
-        inputs =
-            combineInputs (mergedInputs :: mergedInits)
+            (List.map (Signal.map singleton) (config.inputs ++ config.inits))
 
         -- effectsAndModel : Signal (model, Effects action)
         effectsAndModel =
@@ -134,12 +128,3 @@ start config =
         , model = model
         , tasks = Signal.map (Effects.toTask messages.address << snd) effectsAndModel
         }
-
-combineInputs : List (Signal (List action)) -> Signal (List action)
-combineInputs signalList =
-  case List.reverse signalList of
-    [] ->
-        Signal.constant []
-
-    signal :: signals ->
-        List.foldl (Signal.Extra.fairMerge List.append) signal signals

--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -17,6 +17,7 @@ works!**
 import Html exposing (Html)
 import Task
 import Effects exposing (Effects, Never)
+import Signal.Extra exposing (foldp', mapMany)
 
 
 {-| The configuration of an app follows the basic model / update / view pattern
@@ -100,13 +101,17 @@ start config =
         update actions (model, _) =
             List.foldl updateStep (model, Effects.none) actions
 
+        -- updateStart : List Action -> (model, Effects action)
+        updateStart actions =
+            List.foldl updateStep config.init actions
+
         -- inputs : Signal (List action)
         inputs =
-            Signal.mergeMany (messages.signal :: List.map (Signal.map singleton) config.inputs)
+            mapMany List.concat (messages.signal :: List.map (Signal.map singleton) config.inputs)
 
         -- effectsAndModel : Signal (model, Effects action)
         effectsAndModel =
-            Signal.foldp update config.init inputs
+            foldp' update updateStart inputs
 
         model =
             Signal.map fst effectsAndModel


### PR DESCRIPTION
This changes start-app so that it doesn't discard the first value of input signals when it initializes. Personally, I needed this for routing with [`elm-history`](https://github.com/TheSeamau5/elm-history/), but it has been requested multiple times. 

See #35, #19, and #21. 

I'm more than happy to clean this up, or let me know how the approach should change. I couldn't tell whether this wasn't being worked on because you guys are busy, or because it was a bad idea for some reason.

Either way, this is immediately useful to me, and I think others, so I'm hoping we can get it in. Let me know what I should change first!
