### PR TITLE
expose inputs on StartApp.App

### DIFF
--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -53,7 +53,7 @@ type alias Config model action =
     to be producing tasks in response to all sorts of events, so this needs to
     be hooked up to a `port` to ensure they get run.
 -}
-type alias App model =
+type alias App model action =
     { html : Signal Html
     , model : Signal model
     , tasks : Signal (Task.Task Never ())

--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -57,6 +57,7 @@ type alias App model =
     { html : Signal Html
     , model : Signal model
     , tasks : Signal (Task.Task Never ())
+    , inputs : Signal (List action)
     }
 
 
@@ -76,7 +77,7 @@ type alias App model =
 So once we start the `App` we feed the HTML into `main` and feed the resulting
 tasks into a `port` that will run them all.
 -}
-start : Config model action -> App model
+start : Config model action -> App model action
 start config =
     let
         singleton action = [ action ]
@@ -114,4 +115,5 @@ start config =
         { html = Signal.map (config.view address) model
         , model = model
         , tasks = Signal.map (Effects.toTask messages.address << snd) effectsAndModel
+        , inputs = inputs
         }


### PR DESCRIPTION
Exposing inputs on app makes it possible to react to elm actions from javascript. Similar to focusing elements in the elm-todomvc example. Makes it in my opinion more beginner friendly.
