### PR TITLE
Comment addition for StartApp.Config's inputs field

### DIFF
--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -31,6 +31,8 @@ model.
 The `inputs` field is for any external signals you might need. If you need to
 get values from JavaScript, they will come in through a port as a signal which
 you can pipe into your app as one of the `inputs`.
+Note that if multiple updates come in at the same time, the update from the
+left-most signal wins (as with Signal.mergeMany).
 -}
 type alias Config model action =
     { init : (model, Effects action)

--- a/src/StartApp.elm
+++ b/src/StartApp.elm
@@ -32,7 +32,7 @@ The `inputs` field is for any external signals you might need. If you need to
 get values from JavaScript, they will come in through a port as a signal which
 you can pipe into your app as one of the `inputs`.
 Note that if multiple updates come in at the same time, the update from the
-left-most signal wins (as with Signal.mergeMany).
+left-most signal wins (as with [`Signal.mergeMany`](http://package.elm-lang.org/packages/elm-lang/core/latest/Signal#mergeMany)).
 -}
 type alias Config model action =
     { init : (model, Effects action)


### PR DESCRIPTION
To make the user aware of the behaviour, update the comment to mention that in the case of multiple updates coming in at the same time, the left-most update wins. (We were debugging this for a moment)
