### PR TITLE
Update README to add more detailed information about running the example locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,34 @@ update action model =
     Decrement -> model - 1
 ```
 
-> Paste the code into [Elm's online editor][edit] to see it in action. From there, [install Elm on your machine](http://elm-lang.org/install) and start working through the [Elm Architecture tutorial][arch] which starts with this counter example and gradually works up to programs with HTTP and animation.
-
-[edit]: http://elm-lang.org/try
 
 Notice that the `update` and `view` functions are totally separate. This is great for architecture, but it also makes testing way easier. Your application logic is entirely isolated, so you can make sure it works correctly without worrying about the DOM.
 
 So this is a super simple program, but the core concepts here can grow into great code bases if you follow [the Elm Architecture][arch].
+
+__Run the example online__
+
+Paste the code into [Elm's online editor][edit] to see it in action.
+
+[edit]: http://elm-lang.org/try
+
+__Run the example in your machine__
+
+From there, [install Elm on your machine](http://elm-lang.org/install) and, assuming you've copied the example into a file `Counter.elm` in an empty directory, run the following commands inside that directory:
+
+```bash
+# Create an elm-package.json file and install the required packages
+elm-package install -y evancz/start-app
+elm-package install -y evancz/elm-html
+# Compile the example file
+elm-make Counter.elm --output=counter.html
+# Open the compiled file with your browser
+open counter.html
+```
+
+You can read more about this commands in the [Get Started guide][started] or work through the [Elm Architecture tutorial][arch] which starts with this counter example and gradually works up to programs with HTTP and animation.
+
+[started]: http://elm-lang.org/get-started
 
 
 ## Further Learning

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Using Elm is easier than ever
 
+### Important: since version 0.17 of elm-platform, this package has been deprecated and moved into [elm-lang/html](https://github.com/elm-lang/html). Please read [Upgrading to 0.17 guide](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md) for more information.
+
+----
+
+
 Getting started with Elm is now easier than ever with the `StartApp` package.
 
 With [the Elm Architecture][arch], it has never been easier to write modular front-end code that is [shockingly fast][elm-html] and easy to test, refactor, and debug. The `StartApp` package drastically lowers the barrier to entry, setting everything up so you can focus entirely on writing your app.


### PR DESCRIPTION
I've updated the README to include more detailed information about running the example in your own machine. I spent some time (and brain resources) finding what to do after installing Elm in my machine (I know there's a big link from "Install Elm" to "Get Started", but I've missed it the first time) instead learning the syntax or elm language concepts. 

I know there's a similar pull request, but I think this one is clear (no external links, just the information). In fact, this is what I would have liked to find when I looked this package to quick-start with Elm.
