### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # DEPRECATED
 
-The equivalent of this library lives in [`Html.App`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html-App) as of Elm 0.17. You can read more about how this fits into The Elm Architecture [here](http://guide.elm-lang.org/architecture/index.html).
+The equivalent of this library lives in [`Html.App`](http://package.elm-lang.org/packages/elm-lang/html/1.1.0/Html-App) as of Elm 0.17. You can read more about how this fits into The Elm Architecture [here](http://guide.elm-lang.org/architecture/index.html).


### PR DESCRIPTION
Hey Evan!

I'm just starting with elm and am watching misc talks on youtube. As a part of that process, I came across a reference to `start-app` and noticed that the link in  README is not broken. The same applies to the link on the top of the repo's page, but I can't submit a PR for that.

Not sure if my fix is correct at all because `Html.App` has been removed from the html module starting with version 2.0.0, but still submitting a PR to pay your attention. If other people are browsing this repo too, it'd be great if you could spend five mins on redirecting us to a right place.

Exited to explore what elm ecosystem has got!